### PR TITLE
- dfint/dfrus-old; + dos_rescue, dos_rescue_crossplatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ An awesome list of Euphoria related projects on GitHub.
 - https://github.com/BotMaker/old-work
 - https://github.com/BotMaker/packet-ids
 - https://github.com/BotMaker/Rotmg-game-engine
-- https://github.com/dfint/dfrus-old
 - https://github.com/jhammond045/zig
 
 ### Graphics

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ An awesome list of Euphoria related projects on GitHub.
 - https://github.com/gAndy50/EuSigil
 - https://github.com/gAndy50/Euraylib
 - https://github.com/ghaberek/raylibshim
+- https://github.com/insolor/dos_rescue
+- https://github.com/insolor/dos_rescue_crossplatform
 
 ### Guides
 - https://github.com/xecronix/EU_DLLs_complete_guide


### PR DESCRIPTION
- Removed dfint/dfrus-old from games (it's not a game, it's rather a localization patcher for Dwarf Fortress game, but now it's abandoned)
- Added dos_rescue and dos_rescue_crossplatform to Graphics